### PR TITLE
Remove emails from spool when a post was deleted or drafted

### DIFF
--- a/EmailSubscriptionDatabase.php
+++ b/EmailSubscriptionDatabase.php
@@ -122,6 +122,17 @@ class EmailSubscriptionDatabase{
         );
     }
 
+	/**
+	 * Remove all addresses from db to the email spool
+	 *
+	 * @param int $postId
+	 */
+	public function removeAllToSpool($postId){
+		global $wpdb;
+
+		$wpdb->delete($this->spool_table, array('post_id' => $postId));
+	}
+
     /**
      * Add one email to spool.. Like an administrator when testing..
      *

--- a/email-subscription.php
+++ b/email-subscription.php
@@ -217,6 +217,24 @@ add_action('future_to_publish', 'emailSub_publishPost',100);
 
 
 /**
+ * This function is executed when a post is deleted or moved to draft
+ *
+ * @param int|WP_Post $post
+ */
+function emailSub_dePublishPost( $post ) {
+
+	$postId = (is_object($post)? $post->ID : $post);
+
+	//remove deleted post from Spool
+	$emailDb = new EmailSubscriptionDatabase();
+	$emailDb->removeAllToSpool( $postId );
+}
+add_action('delete_post', 'emailSub_dePublishPost',100);
+add_action('wp_trash_post', 'emailSub_dePublishPost',100);
+add_action('publish_to_draft', 'emailSub_dePublishPost',100);
+
+
+/**
  * Return the post excerpt
  * 
  * @param unknown_type $post


### PR DESCRIPTION
After you draft or move to the trash a post, it still appears at the sender spool list.
When the email was sended by the cron you receive an email with empty body and broken links.